### PR TITLE
Jacoco plugin for unit tests coverage

### DIFF
--- a/components/org.wso2.carbon.identity.user.store.remote/pom.xml
+++ b/components/org.wso2.carbon.identity.user.store.remote/pom.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
+<?xml version="1.0" encoding="UTF-8"?><!--
   Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 
   WSO2 Inc. licenses this file to you under the Apache License,
@@ -15,22 +14,18 @@
   KIND, either express or implied. See the License for the
   specific language governing permissions and limitations
   under the License.
-  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
+  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.wso2.carbon.identity.userstore.remote</groupId>
         <artifactId>identity-userstore-remote</artifactId>
         <relativePath>../../pom.xml</relativePath>
         <version>5.1.4-SNAPSHOT</version>
     </parent>
-
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.carbon.identity.user.store.remote</artifactId>
     <packaging>bundle</packaging>
     <name>WSO2 Carbon Remote Userstore</name>
     <description>WSO2 Carbon Remote Userstore</description>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.axis2.wso2</groupId>
@@ -57,7 +52,6 @@
             <artifactId>org.wso2.carbon.logging</artifactId>
         </dependency>
     </dependencies>
-
     <build>
         <plugins>
             <plugin>
@@ -92,7 +86,14 @@
                     </instructions>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,8 @@
         <maven.compiler.plugin.version>2.3.1</maven.compiler.plugin.version>
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
+	<jacoco.maven.plugin.version>0.8.0</jacoco.maven.plugin.version>
+	<jacoco.maven.plugin.version>2.21.0</jacoco.maven.plugin.version>
     </properties>
     <build>
         <pluginManagement>
@@ -225,7 +227,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.0</version>
+                    <version>${jacoco.maven.plugin.version}0.8.0</version>
                     <executions>
                         <execution>
                             <id>default-prepare-agent-by-coverage-enforcer</id>
@@ -246,35 +248,12 @@
                                 <dataFile>${project.build.directory}/jacoco.exec</dataFile>
                             </configuration>
                         </execution>
-                        <execution>
-                            <id>default-check-by-coverage-enforcer</id>
-                            <goals>
-                                <goal>check</goal>
-                            </goals>
-                            <configuration>
-                                <dataFile>${project.build.directory}/jacoco.exec</dataFile>
-                                <rules>
-                                    <!-- implementation is needed only for Maven 2 -->
-                                    <rule implementation="org.jacoco.maven.RuleConfiguration">
-                                        <element>BUNDLE</element>
-                                        <limits>
-                                            <!-- implementation is needed only for Maven 2 -->
-                                            <limit implementation="org.jacoco.report.check.Limit">
-                                                <counter>LINE</counter>
-                                                <value>COVEREDRATIO</value>
-                                                <minimum>0.0</minimum>
-                                            </limit>
-                                        </limits>
-                                    </rule>
-                                </rules>
-                            </configuration>
-                        </execution>
                     </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.21.0</version>
+                    <version>${maven.surefire.plugin.version}</version>
                     <configuration>
                         <argLine>${argLine}</argLine>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
   ~
   ~ WSO2 Inc. licenses this file to you under the Apache License,
@@ -15,39 +14,31 @@
   ~ KIND, either express or implied.  See the License for the
   ~ specific language governing permissions and limitations
   ~ under the License.
-  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-
+  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <groupId>org.wso2</groupId>
         <artifactId>wso2</artifactId>
         <version>1</version>
     </parent>
-
     <groupId>org.wso2.carbon.identity.userstore.remote</groupId>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>identity-userstore-remote</artifactId>
     <version>5.1.4-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>WSO2 Carbon Remote Userstore Module</name>
-    <description>
-
-    </description>
+    <description/>
     <url>http://wso2.org</url>
-
     <modules>
         <module>components/org.wso2.carbon.identity.user.store.remote</module>
         <module>features/org.wso2.carbon.identity.user.store.remote.server.feature</module>
         <module>features/org.wso2.carbon.identity.user.store.remote.feature</module>
     </modules>
-
     <scm>
         <url>https://github.com/wso2-extensions/identity-userstore-remote.git</url>
         <developerConnection>scm:git:https://github.com/wso2-extensions/identity-userstore-remote.git</developerConnection>
         <connection>scm:git:https://github.com/wso2-extensions/identity-userstore-remote.git</connection>
         <tag>HEAD</tag>
     </scm>
-
     <repositories>
         <repository>
             <id>wso2-nexus</id>
@@ -59,7 +50,6 @@
                 <checksumPolicy>ignore</checksumPolicy>
             </releases>
         </repository>
-
         <repository>
             <id>wso2.releases</id>
             <name>WSO2 internal Repository</name>
@@ -70,7 +60,6 @@
                 <checksumPolicy>ignore</checksumPolicy>
             </releases>
         </repository>
-
         <repository>
             <id>wso2.snapshots</id>
             <name>Apache Snapshot Repository</name>
@@ -83,10 +72,7 @@
                 <enabled>false</enabled>
             </releases>
         </repository>
-
     </repositories>
-
-
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -137,9 +123,6 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
-
-
     <pluginRepositories>
         <pluginRepository>
             <id>wso2.releases</id>
@@ -151,7 +134,6 @@
                 <checksumPolicy>ignore</checksumPolicy>
             </releases>
         </pluginRepository>
-
         <pluginRepository>
             <id>wso2.snapshots</id>
             <name>WSO2 Snapshot Repository</name>
@@ -175,10 +157,8 @@
             </releases>
         </pluginRepository>
     </pluginRepositories>
-
     <properties>
         <identity.userstore.remote.version>${project.version}</identity.userstore.remote.version>
-
         <carbon.kernel.version>4.4.7</carbon.kernel.version>
         <carbon.kernel.package.import.version.range>[4.4.0, 5.0.0)</carbon.kernel.package.import.version.range>
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
@@ -189,17 +169,14 @@
         <commons-logging.osgi.version.range>[1.2,2.0)</commons-logging.osgi.version.range>
         <osgi.service.component.imp.pkg.version.range>[1.2.0, 2.0.0)</osgi.service.component.imp.pkg.version.range>
         <osgi.framework.imp.pkg.version.range>[1.7.0, 2.0.0)</osgi.framework.imp.pkg.version.range>
-
         <identity.user.ws.version>5.1.3</identity.user.ws.version>
         <identity.user.ws.package.import.version.range>[5.0.0, 6.0.0)</identity.user.ws.package.import.version.range>
-
         <maven.scr.plugin.version>1.7.2</maven.scr.plugin.version>
         <maven.bundle.plugin.version>2.4.0</maven.bundle.plugin.version>
         <maven.compiler.plugin.version>2.3.1</maven.compiler.plugin.version>
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
     </properties>
-
     <build>
         <pluginManagement>
             <plugins>
@@ -245,9 +222,65 @@
                         <doUpdate>false</doUpdate>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>0.8.0</version>
+                    <executions>
+                        <execution>
+                            <id>default-prepare-agent-by-coverage-enforcer</id>
+                            <goals>
+                                <goal>prepare-agent</goal>
+                            </goals>
+                            <configuration>
+                                <propertyName>argLine</propertyName>
+                                <destFile>${project.build.directory}/jacoco.exec</destFile>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>default-report-by-coverage-enforcer</id>
+                            <goals>
+                                <goal>report</goal>
+                            </goals>
+                            <configuration>
+                                <dataFile>${project.build.directory}/jacoco.exec</dataFile>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>default-check-by-coverage-enforcer</id>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                            <configuration>
+                                <dataFile>${project.build.directory}/jacoco.exec</dataFile>
+                                <rules>
+                                    <!-- implementation is needed only for Maven 2 -->
+                                    <rule implementation="org.jacoco.maven.RuleConfiguration">
+                                        <element>BUNDLE</element>
+                                        <limits>
+                                            <!-- implementation is needed only for Maven 2 -->
+                                            <limit implementation="org.jacoco.report.check.Limit">
+                                                <counter>LINE</counter>
+                                                <value>COVEREDRATIO</value>
+                                                <minimum>0.0</minimum>
+                                            </limit>
+                                        </limits>
+                                    </rule>
+                                </rules>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.21.0</version>
+                    <configuration>
+                        <argLine>${argLine}</argLine>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
-
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -277,10 +310,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>
-
-
-
-
-

--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
 	<jacoco.maven.plugin.version>0.8.0</jacoco.maven.plugin.version>
-	<jacoco.maven.plugin.version>2.21.0</jacoco.maven.plugin.version>
+	<maven.surefire.plugin.version>2.21.0</maven.surefire.plugin.version>
     </properties>
     <build>
         <pluginManagement>
@@ -227,7 +227,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>${jacoco.maven.plugin.version}0.8.0</version>
+                    <version>${jacoco.maven.plugin.version}</version>
                     <executions>
                         <execution>
                             <id>default-prepare-agent-by-coverage-enforcer</id>


### PR DESCRIPTION
## Purpose
Generate unit test coverage information 

## Goals
Integrate Jacoco Maven plugin with Maven Surefire plugin to generate unit test coverage information for 'components/org.wso2.carbon.identity.user.store.remote'

## Approach
N/A

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
N/A

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A

## Learning
N/A